### PR TITLE
removed datafile from link in template as not needed

### DIFF
--- a/django/core/local_settings.example.py
+++ b/django/core/local_settings.example.py
@@ -37,6 +37,3 @@ DATABASES = {
         },
     }
 }
-
-# Specify the root directory path for use in the 'data' app
-DATA_ROOT = "path/to/data/folder"

--- a/django/core/local_settings.test.py
+++ b/django/core/local_settings.test.py
@@ -29,5 +29,3 @@ DATABASES = {
         },
     }
 }
-
-DATA_ROOT = "path/to/data/folder"

--- a/django/core/local_settings_dataroot.example.py
+++ b/django/core/local_settings_dataroot.example.py
@@ -8,3 +8,5 @@ so that it can be more easily managed by Salt.
 
 # The path of the root data folder
 DATA_ROOT = "/path/to/local/data/folder"
+# The name of the dir inside data root where the data files are stored
+DATA_ROOT_FILES = "files"

--- a/django/core/local_settings_dataroot.example.py
+++ b/django/core/local_settings_dataroot.example.py
@@ -8,5 +8,5 @@ so that it can be more easily managed by Salt.
 
 # The path of the root data folder
 DATA_ROOT = "/path/to/local/data/folder"
-# The name of the dir inside data root where the data files are stored
+# This is prefixed to the URLs generated for files found within DATA_ROOT
 DATA_ROOT_FILES = "files"

--- a/django/core/settings.py
+++ b/django/core/settings.py
@@ -116,6 +116,6 @@ if not SECRET_KEY:  # NOQA
 
 # Import local_settings_dataroot.py
 try:
-    from .local_settings_dataroot import DATA_ROOT  # NOQA
+    from .local_settings_dataroot import *  # NOQA
 except ImportError:
     sys.exit('Unable to import local_settings_dataroot.py (refer to local_settings_dataroot.example.py)')

--- a/django/data/templates/data/data.html
+++ b/django/data/templates/data/data.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% load static %}
+{% load settings_value %}
 
 {% block main %}
 
@@ -40,7 +41,7 @@
     </div>
     <div id="data-files">
         {% for file in file_list %}
-            <a href="/{{ file.filepath }}" class="data-file data-object" title="{{ file.name_full }}">
+            <a href="/{% settings_value 'DATA_ROOT_FILES' %}{{ file.filepath }}" class="data-file data-object" title="{{ file.name_full }}">
                 <div class="data-file-icon">
                     <i class="fas fa-file"></i>
                 </div>

--- a/django/data/templates/data/data.html
+++ b/django/data/templates/data/data.html
@@ -40,7 +40,7 @@
     </div>
     <div id="data-files">
         {% for file in file_list %}
-            <a href="/datafiles/{{ file.filepath }}" class="data-file data-object" title="{{ file.name_full }}">
+            <a href="/{{ file.filepath }}" class="data-file data-object" title="{{ file.name_full }}">
                 <div class="data-file-icon">
                     <i class="fas fa-file"></i>
                 </div>

--- a/django/data/templatetags/settings_value.py
+++ b/django/data/templatetags/settings_value.py
@@ -3,7 +3,7 @@ from django.conf import settings
 
 register = template.Library()
 
-# settings value
+
 @register.simple_tag
 def settings_value(name):
     print(getattr(settings, name, ""))

--- a/django/data/templatetags/settings_value.py
+++ b/django/data/templatetags/settings_value.py
@@ -1,0 +1,10 @@
+from django import template
+from django.conf import settings
+
+register = template.Library()
+
+# settings value
+@register.simple_tag
+def settings_value(name):
+    print(getattr(settings, name, ""))
+    return getattr(settings, name, "")

--- a/django/data/templatetags/settings_value.py
+++ b/django/data/templatetags/settings_value.py
@@ -6,5 +6,4 @@ register = template.Library()
 
 @register.simple_tag
 def settings_value(name):
-    print(getattr(settings, name, ""))
     return getattr(settings, name, "")


### PR DESCRIPTION
During dev, I added 'datafiles/' to the start of the links to the files, but it instead needs to be set as 'files'.

I've changed this to be defined in the local settings (data root) file, so it can be shared with Salt for use on live server.

To make this local setting accessible in the template, I've added a generic template tag for accessing settings in templates.

I also found that the old DATA_ROOT setting was still in the general local settings file by mistake, so removed this.